### PR TITLE
fix(): nsd-control-setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,16 @@ RUN apk -U add \
     openssl \
   && rm -f /var/cache/apk/*
 
-RUN nsd-control-setup
-
 COPY keygen /usr/sbin/keygen
 COPY signzone /usr/sbin/signzone
 COPY ds-records /usr/sbin/ds-records
+COPY startup /usr/sbin/startup
 
 RUN chmod +x /usr/sbin/keygen \
              /usr/sbin/signzone \
-             /usr/sbin/ds-records
+             /usr/sbin/ds-records \
+             /usr/sbin/startup
 
 VOLUME /zones /etc/nsd
 EXPOSE 53 53/udp
-CMD ["nsd", "-d"]
+CMD ["startup"]

--- a/startup
+++ b/startup
@@ -1,0 +1,5 @@
+#!/bin/sh
+if [ ! -f /etc/nsd/nsd_server.pem ]; then
+  nsd-control-setup
+fi
+nsd -d


### PR DESCRIPTION
Vu qu'on monte `/etc/nsd`, initialiser avec `nsd-control-setup` dans le `Dockerfile` ne sert à rien et est dangereux si l'utilisateur pull depuis l'automated build (génération de clés au moment du build). Je propose que ça se fasse au démarrage du conteneur si les clés ne sont pas présentes. 
