### PR TITLE
Some improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,28 @@
 FROM alpine:3.3
 MAINTAINER Hardware <contact@meshup.net>
 
-RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
- && echo "@commuedge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+ARG NSD_VERSION=4.1.9
+
+ENV UID=991 GID=991
+
+RUN echo "@commuedge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+ && BUILD_DEPS=" \
+    build-base \
+    libevent-dev \
+    openssl-dev \
+    ca-certificates" \
  && apk -U add \
-    nsd \
+    ${BUILD_DEPS} \
     ldns \
     ldns-tools \
-    libressl@testing \
+    libevent \
+    openssl \
     tini@commuedge \
- && rm -f /var/cache/apk/*
+ && cd /tmp && wget -q https://www.nlnetlabs.nl/downloads/nsd/nsd-${NSD_VERSION}.tar.gz \
+ && tar xzf nsd-${NSD_VERSION}.tar.gz && cd nsd-${NSD_VERSION} \
+ && ./configure && make && make install \
+ && apk del ${BUILD_DEPS} \
+ && rm -rf /var/cache/apk/* /tmp/*
 
 COPY keygen /usr/sbin/keygen
 COPY signzone /usr/sbin/signzone
@@ -21,6 +34,6 @@ RUN chmod +x /usr/sbin/keygen \
              /usr/sbin/ds-records \
              /usr/sbin/startup
 
-VOLUME /zones /etc/nsd
+VOLUME /zones /etc/nsd /var/db/nsd
 EXPOSE 53 53/udp
-CMD ["tini","--","startup"]
+CMD ["/sbin/tini","--","startup"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ NSD is an authoritative only, high performance, simple and open source name serv
 
 - Docker 1.0 or higher
 
+### Build-time variables
+
+- **NSD_VERSION** : version of NSD
+
+### Environment variables
+
+- **UID** : nsd user id *(default : 991)*
+- **GID** : nsd group id *(default : 991)*
+
 ### How to use
 
 ```
@@ -17,6 +26,7 @@ docker run -d \
   -p 53:53/udp \
   -v /mnt/docker/nsd/conf:/etc/nsd \
   -v /mnt/docker/nsd/zones:/zones \
+  -v /mnt/docker/nsd/db:/var/db/nsd \
   hardware/nsd-dnssec
 ```
 
@@ -156,6 +166,7 @@ nsd:
   volumes:
     - /mnt/docker/nsd/conf:/etc/nsd
     - /mnt/docker/nsd/zones:/zones
+    - /mnt/docker/nsd/db:/var/db/nsd
 ```
 
 #### Run !

--- a/startup
+++ b/startup
@@ -1,7 +1,13 @@
 #!/bin/sh
 
+if [ "$(grep -c 'nsd:' /etc/passwd)" != "1" ]; then
+  addgroup -g ${GID} nsd && adduser -H -s /sbin/nologin -D -G nsd -u ${UID} nsd
+fi
+
+chown -R ${UID}:${GID} /var/db/nsd/
+
 if [ ! -f /etc/nsd/nsd_server.pem ]; then
   nsd-control-setup
 fi
 
-nsd -d
+nsd -P /dev/null -d


### PR DESCRIPTION
- NSD is now built from source.
- Volume /var/db/nsd added.
- nsd UID/GID flexibility (useful? but still welcome).
- Resolved tini warnings (use /sbin/tini).
- Resolved pidfile warnings (no more pidfile).
- LibreSSL (not maintained enough by Alpine) replaced with OpenSSL.

De plus, nous passons ainsi de 10.19MB à 10.05MB. 💪
