### PR TITLE
Update signzone

### DIFF
--- a/signzone
+++ b/signzone
@@ -16,7 +16,7 @@ cd /zones || exit 1
 
 echo "Signing zone for ${DOMAIN}"
 ldns-signzone -n -p ${arg} -s "$(head /dev/urandom | tr -dc A-Za-z0-9 | sha1sum | head -c 30)" \
-  -f "db.${DOMAIN}.signed" "db.${DOMAIN}" "K${DOMAIN}.zsk" "K${DOMAIN}.ksk"
+  -f "db.${DOMAIN}.signed" "db.${DOMAIN}" "K${DOMAIN}.zsk.key" "K${DOMAIN}.ksk.key"
 
 echo -n "NSD configuration rebuild... "
 nsd-control reconfig


### PR DESCRIPTION
Signzone not working because it couldn't find zsk and ksk key files because they are created with a .key extension by  keygen script