### PR TITLE
Cleanup apk executions and remove the extra community repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,20 +13,18 @@ ARG SHA256_HASH="1bab5f30406cabac2f2cc95f8af6dfe20581646a75a70c091845e04d325f4ee
 
 ENV UID=991 GID=991
 
-RUN echo "@community https://nl.alpinelinux.org/alpine/v3.9/community" >> /etc/apk/repositories \
- && apk -U upgrade \
- && apk add -t build-dependencies \
+RUN apk add --no-cache --virtual build-dependencies \
       gnupg \
       build-base \
       libevent-dev \
       openssl-dev \
       ca-certificates \
- && apk add \
+ && apk add --no-cache \
       ldns \
       ldns-tools \
       libevent \
       openssl \
-      tini@community \
+      tini \
  && cd /tmp \
  && wget -q https://www.nlnetlabs.nl/downloads/nsd/nsd-${NSD_VERSION}.tar.gz \
  && wget -q https://www.nlnetlabs.nl/downloads/nsd/nsd-${NSD_VERSION}.tar.gz.asc \


### PR DESCRIPTION
The community repo was used to pull in tini from edge back in the days of alpine 3.3 (which did not include tini).  This is no longer necessary.

ref commit 63a2fc82db5b7488616723f58baf320dcaa93b48